### PR TITLE
Draft: Logs signal

### DIFF
--- a/internal/logs/otlp.go
+++ b/internal/logs/otlp.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logs // import "go.opentelemetry.io/collector/receiver/otlpreceiver/internal/logs"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver/internal/errors"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+)
+
+const dataFormatProtobuf = "protobuf"
+
+// Receiver is the type used to handle logs from OpenTelemetry exporters.
+type Receiver struct {
+	plogotlp.UnimplementedGRPCServer
+	nextConsumer consumer.Logs
+	obsreport    *receiverhelper.ObsReport
+}
+
+// New creates a new Receiver reference.
+func New(nextConsumer consumer.Logs, obsreport *receiverhelper.ObsReport) *Receiver {
+	return &Receiver{
+		nextConsumer: nextConsumer,
+		obsreport:    obsreport,
+	}
+}
+
+// Export implements the service Export logs func.
+func (r *Receiver) Export(ctx context.Context, req plogotlp.ExportRequest) (plogotlp.ExportResponse, error) {
+	ld := req.Logs()
+	numSpans := ld.LogRecordCount()
+	if numSpans == 0 {
+		return plogotlp.NewExportResponse(), nil
+	}
+
+	ctx = r.obsreport.StartLogsOp(ctx)
+	err := r.nextConsumer.ConsumeLogs(ctx, ld)
+	r.obsreport.EndLogsOp(ctx, dataFormatProtobuf, numSpans, err)
+
+	// Use appropriate status codes for permanent/non-permanent errors
+	// If we return the error straightaway, then the grpc implementation will set status code to Unknown
+	// Refer: https://github.com/grpc/grpc-go/blob/v1.59.0/server.go#L1345
+	// So, convert the error to appropriate grpc status and return the error
+	// NonPermanent errors will be converted to codes.Unavailable (equivalent to HTTP 503)
+	// Permanent errors will be converted to codes.InvalidArgument (equivalent to HTTP 400)
+	if err != nil {
+		return plogotlp.NewExportResponse(), errors.GetStatusFromError(err)
+	}
+
+	return plogotlp.NewExportResponse(), nil
+}

--- a/internal/logs/otlp_test.go
+++ b/internal/logs/otlp_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/testdata"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+func TestExport(t *testing.T) {
+	ld := testdata.GenerateLogs(1)
+	req := plogotlp.NewExportRequestFromLogs(ld)
+
+	logSink := new(consumertest.LogsSink)
+	logClient := makeLogsServiceClient(t, logSink)
+	resp, err := logClient.Export(context.Background(), req)
+	require.NoError(t, err, "Failed to export trace: %v", err)
+	require.NotNil(t, resp, "The response is missing")
+
+	lds := logSink.AllLogs()
+	require.Len(t, lds, 1)
+	assert.EqualValues(t, ld, lds[0])
+}
+
+func TestExport_EmptyRequest(t *testing.T) {
+	logSink := new(consumertest.LogsSink)
+
+	logClient := makeLogsServiceClient(t, logSink)
+	resp, err := logClient.Export(context.Background(), plogotlp.NewExportRequest())
+	require.NoError(t, err, "Failed to export trace: %v", err)
+	assert.NotNil(t, resp, "The response is missing")
+}
+
+func TestExport_NonPermanentErrorConsumer(t *testing.T) {
+	ld := testdata.GenerateLogs(1)
+	req := plogotlp.NewExportRequestFromLogs(ld)
+
+	logClient := makeLogsServiceClient(t, consumertest.NewErr(errors.New("my error")))
+	resp, err := logClient.Export(context.Background(), req)
+	require.EqualError(t, err, "rpc error: code = Unavailable desc = my error")
+	assert.IsType(t, status.Error(codes.Unknown, ""), err)
+	assert.Equal(t, plogotlp.ExportResponse{}, resp)
+}
+
+func TestExport_PermanentErrorConsumer(t *testing.T) {
+	ld := testdata.GenerateLogs(1)
+	req := plogotlp.NewExportRequestFromLogs(ld)
+
+	logClient := makeLogsServiceClient(t, consumertest.NewErr(consumererror.NewPermanent(errors.New("my error"))))
+	resp, err := logClient.Export(context.Background(), req)
+	require.EqualError(t, err, "rpc error: code = Internal desc = Permanent error: my error")
+	assert.IsType(t, status.Error(codes.Unknown, ""), err)
+	assert.Equal(t, plogotlp.ExportResponse{}, resp)
+}
+
+func makeLogsServiceClient(t *testing.T, lc consumer.Logs) plogotlp.GRPCClient {
+	addr := otlpReceiverOnGRPCServer(t, lc)
+	cc, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "Failed to create the TraceServiceClient: %v", err)
+	t.Cleanup(func() {
+		require.NoError(t, cc.Close())
+	})
+
+	return plogotlp.NewGRPCClient(cc)
+}
+
+func otlpReceiverOnGRPCServer(t *testing.T, lc consumer.Logs) net.Addr {
+	ln, err := net.Listen("tcp", "localhost:")
+	require.NoError(t, err, "Failed to find an available address to run the gRPC server: %v", err)
+
+	t.Cleanup(func() {
+		require.NoError(t, ln.Close())
+	})
+
+	set := receivertest.NewNopSettings()
+	set.ID = component.MustNewIDWithName("otlp", "log")
+	obsreport, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		ReceiverID:             set.ID,
+		Transport:              "grpc",
+		ReceiverCreateSettings: set,
+	})
+	require.NoError(t, err)
+	r := New(lc, obsreport)
+	// Now run it as a gRPC server
+	srv := grpc.NewServer()
+	plogotlp.RegisterGRPCServer(srv, r)
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+
+	return ln.Addr()
+}


### PR DESCRIPTION
Libhoney can emit events that don't follow the trace pattern.

This change allows the receiver to pass data along as either a log or a trace.

If it's been processed by Husky, there may be a bit of damage to the original format, particularly the body field. Things may have been separated out into multiple attributes that don't reassemble. Will have to see how it performs in the real world to see if it needs adjustment. 